### PR TITLE
Hide subscribe link in header

### DIFF
--- a/partials/header.hbs
+++ b/partials/header.hbs
@@ -49,9 +49,11 @@
             </div>
         </div>
     {{/if}}
+    {{#is "post"}}
     <div class="header-right hidden-xs hidden-sm hidden-md">
         <button class="button-text menu-item menu-item-cta members-subscribe" data-portal="signup">Subscribe</button>
     </div>
+    {{/is}}
 </header>
 
 {{#is "post"}}


### PR DESCRIPTION
Hide the subscribe link in the header so we don't have 3 "Subscribe" links visible.

Will show it still on a post page because it doesn't have the subscribe button from the frontpage.

(this PR is already published)